### PR TITLE
Init: add password field & interfaces

### DIFF
--- a/src/main/java/wanted/moneymwoni/app/member/domain/Member.java
+++ b/src/main/java/wanted/moneymwoni/app/member/domain/Member.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
+import wanted.moneymwoni.app.member.exception.PasswordMismatch;
 
 @Entity
 @Table(
@@ -23,11 +24,29 @@ public class Member {
     @Column(name = "member_id")
     private Long id;
 
-    @Column(name = "member_name")
+    @Column(name = "member_name", nullable = false)
     private String name;
 
+    @Column(name = "member_password", nullable = false)
+    private String password;
+
     @Builder
-    public Member(String name) {
+    public Member(String name,
+                  String rawPassword,
+                  PasswordHasher hasher) {
         this.name = name;
+        this.password = hasher.hash(rawPassword);
     }
+
+    public void verifyPassword(String rawPassword, PasswordHasher hasher) {
+        if (!hasher.isMatch(rawPassword, password)) {
+            throw new PasswordMismatch();
+        }
+    }
+
+    public void updatePassword(String rawPassword, PasswordValidator validator, PasswordHasher hasher) {
+        validator.validate(this, rawPassword, hasher);
+        this.password = hasher.hash(rawPassword);
+    }
+
 }

--- a/src/main/java/wanted/moneymwoni/app/member/domain/PasswordHasher.java
+++ b/src/main/java/wanted/moneymwoni/app/member/domain/PasswordHasher.java
@@ -1,0 +1,8 @@
+package wanted.moneymwoni.app.member.domain;
+
+public interface PasswordHasher {
+
+    String hash(String rawPassword);
+
+    boolean isMatch(String raw, String hashed);
+}

--- a/src/main/java/wanted/moneymwoni/app/member/domain/PasswordValidator.java
+++ b/src/main/java/wanted/moneymwoni/app/member/domain/PasswordValidator.java
@@ -1,0 +1,6 @@
+package wanted.moneymwoni.app.member.domain;
+
+public interface PasswordValidator {
+
+    void validate(Member member, String rawPassword, PasswordHasher passwordHasher);
+}

--- a/src/main/java/wanted/moneymwoni/app/member/exception/PasswordMismatch.java
+++ b/src/main/java/wanted/moneymwoni/app/member/exception/PasswordMismatch.java
@@ -1,0 +1,5 @@
+package wanted.moneymwoni.app.member.exception;
+
+public class PasswordMismatch extends RuntimeException {
+
+}


### PR DESCRIPTION
Member Entity 상에 Password 필드를 추가하고 해당 로직에 필요한 객체들의 인터페이스를 만들었습니다.

로직상 필요로 Password mismatch 상황에서 사용될 exception을 하나 만들었습니다.